### PR TITLE
Redirect away from authentication pages if user is authenticated

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -2,7 +2,7 @@ require 'devise/version'
 
 class Devise::TwoFactorAuthenticationController < DeviseController
   prepend_before_action :authenticate_scope!
-  before_action :prepare_and_validate, :handle_two_factor_authentication
+  before_action :redirect_if_authenticated, :prepare_and_validate, :handle_two_factor_authentication
 
   def show
   end
@@ -28,6 +28,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     set_remember_two_factor_cookie(resource)
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+
     # For compatability with devise versions below v4.2.0
     # https://github.com/plataformatec/devise/commit/2044fffa25d781fcbaf090e7728b48b65c854ccb
     if respond_to?(:bypass_sign_in)
@@ -50,6 +51,10 @@ class Devise::TwoFactorAuthenticationController < DeviseController
           expires: expires_seconds.from_now
       }
     end
+  end
+
+  def redirect_if_authenticated
+    redirect_to after_two_factor_success_path_for(resource) if is_fully_authenticated?
   end
 
   def after_two_factor_success_path_for(resource)

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -54,6 +54,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def redirect_if_authenticated
+    flash.discard
     redirect_to after_two_factor_success_path_for(resource) if is_fully_authenticated?
   end
 

--- a/spec/controllers/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication_controller_spec.rb
@@ -30,4 +30,43 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
       end
     end
   end
+
+  describe 'redirect_if_authenticated' do
+    before do
+      sign_in
+    end
+
+    context 'after user enters valid OTP code' do
+      before do
+        controller.current_user.send_new_otp
+        post :update, code: controller.current_user.direct_otp
+      end
+
+      it 'redirects away from authentication page' do
+        get :show
+
+        expect(response.code).to eq '302'
+      end
+    end
+
+    context 'when user has not entered any OTP yet' do
+      it 'does not redirect' do
+        get :show
+
+        expect(response.code).to eq '200'
+      end
+    end
+
+    context 'when user enters an invalid OTP' do
+      before do
+        post :update, code: '12345'
+      end
+
+      it 'does not redirect' do
+        get :show
+
+        expect(response.code).to eq '200'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ran into an issue where even after entering the correct OTP, the user was shown the authentication page again. This may be because we are not using cookies to remember users (i.e., `remember_otp_session_for_seconds` is the default of `0`). This solution is to perform a redirect to the `after_two_factor_success_path_for` if the user `is_fully_authenticated?`.

Also, clear `flash` message before redirecting if authenticated. Whatever was causing users to stay on authentication page even after they successfully entered a OTP was also setting a flash error message. Since we are now redirecting if they are authenticated, we can safely discard the flash so they do not see an irrelevant error message.