### PR TITLE
Remove success flash message

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -36,7 +36,6 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     else
       sign_in(resource_name, resource, bypass: true)
     end
-    set_flash_message :notice, :success
     resource.update_attribute(:second_factor_attempts_count, 0)
 
     redirect_to after_two_factor_success_path_for(resource)


### PR DESCRIPTION
Don't show the flash message after successfully authenticating. It is not really necessary since the user will know, by the very fact that they have logged in, that it was successful.